### PR TITLE
Add patch to fix launch-method argument

### DIFF
--- a/recipe/1565-fix-usage-of-launch-method-config.patch
+++ b/recipe/1565-fix-usage-of-launch-method-config.patch
@@ -1,0 +1,29 @@
+From d8284fd993340660d9d935dd8908e05876d7d9f2 Mon Sep 17 00:00:00 2001
+From: Mark Harfouche <mark.harfouche@gmail.com>
+Date: Sat, 6 Dec 2025 09:14:26 -0500
+Subject: [PATCH] Fixup how the default launch method is chosen
+
+---
+ asv/commands/common_args.py | 9 +++++++--
+ 1 file changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/asv/commands/common_args.py b/asv/commands/common_args.py
+index 1bfc9782e..a0c050904 100644
+--- a/asv/commands/common_args.py
++++ b/asv/commands/common_args.py
+@@ -289,8 +289,13 @@ def add_launch_method(parser):
+         dest="launch_method",
+         action="store",
+         choices=("auto", "spawn", "forkserver"),
+-        default="auto",
+-        help="How to launch benchmarks. Choices: auto, spawn, forkserver",
++        default=None,
++        help=(
++            "How to launch benchmarks. Choices: auto, spawn, forkserver. "
++            "By default asv will look in the asv.conf.json file, if not, auto "
++            "will be used."
++        ),
++
+     )
+ 
+ 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,12 +9,17 @@ source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: a8eeb7c5037cd78c146bd727d27203132438d4d62f36e669eb0cd5d63da0cf39
   patches:
+    # https://github.com/airspeed-velocity/asv/pull/1558
     - 1558-correctly-formed-conda-requirements.patch
+    # https://github.com/airspeed-velocity/asv/pull/1559
     - 1559-correct_units_meminfo.patch
+    # https://github.com/airspeed-velocity/asv/pull/1560
     - 1560-launch_method_in_config.patch
+    # https://github.com/airspeed-velocity/asv/pull/1565
+    - 1565-fix-usage-of-launch-method-config.patch
 
 build:
-  number: 2
+  number: 3
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:


### PR DESCRIPTION
This fixes https://github.com/airspeed-velocity/asv/pull/1565

I guess i forgot to commit this at the time of writing my original patch to ASV upstream


I'm mostly writing this a patch for myself so i can build this package for my own usage.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
