### PR TITLE
Rebuild asv 0.6.6 once asv_runner 0.2.5 is on conda-forge

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:


### PR DESCRIPTION
## Why main was red

Azure build [1544926](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=1544926) failed native jobs because **`asv_runner >=0.2.5` was not on the conda-forge CDN** (solvers reported it did not exist). Cross osx_arm64 could still look green without a full run-dep solve in the test env.

## This PR

- Keep **asv 0.6.6** and run pin **`asv_runner >=0.2.5`** (do not relax).
- Bump **build number → 1** so CI rebuilds against a channel that has `asv_runner` 0.2.5.

## Prerequisite (merged)

- [asv_runner-feedstock#8](https://github.com/conda-forge/asv_runner-feedstock/pull/8) — 0.2.5 (GitHub tag source; PyPI was wheel-only)
- [asv_runner-feedstock#9](https://github.com/conda-forge/asv_runner-feedstock/pull/9) — CFEP-25 `python_min` pins
- [asv_runner-feedstock#10](https://github.com/conda-forge/asv_runner-feedstock/pull/10) — rebuild so artifacts land on `conda.anaconda.org`